### PR TITLE
fix: ensure createdBy/updatedBy are set on document creation

### DIFF
--- a/packages/monguard/src/monguard-collection.ts
+++ b/packages/monguard/src/monguard-collection.ts
@@ -223,10 +223,10 @@ export class MonguardCollection<T extends BaseDocument, TRefId = DefaultReferenc
         if (shouldSetTimestamps && fields.updatedAt !== false) {
           (timestamped as any).updatedAt = timestamp;
         }
-        if (shouldSetUserFields && fields.createdBy !== false && 'createdBy' in timestamped) {
+        if (shouldSetUserFields && fields.createdBy !== false) {
           (timestamped as any).createdBy = options.userContext!.userId;
         }
-        if (shouldSetUserFields && fields.updatedBy !== false && 'updatedBy' in timestamped) {
+        if (shouldSetUserFields && fields.updatedBy !== false) {
           (timestamped as any).updatedBy = options.userContext!.userId;
         }
         break;
@@ -235,7 +235,7 @@ export class MonguardCollection<T extends BaseDocument, TRefId = DefaultReferenc
         if (shouldSetTimestamps && fields.updatedAt !== false) {
           (timestamped as any).updatedAt = timestamp;
         }
-        if (shouldSetUserFields && fields.updatedBy !== false && 'updatedBy' in timestamped) {
+        if (shouldSetUserFields && fields.updatedBy !== false) {
           (timestamped as any).updatedBy = options.userContext!.userId;
         }
         break;
@@ -247,10 +247,10 @@ export class MonguardCollection<T extends BaseDocument, TRefId = DefaultReferenc
         if (shouldSetTimestamps && fields.updatedAt !== false) {
           (timestamped as any).updatedAt = timestamp;
         }
-        if (shouldSetUserFields && fields.deletedBy !== false && 'deletedBy' in timestamped) {
+        if (shouldSetUserFields && fields.deletedBy !== false) {
           (timestamped as any).deletedBy = options.userContext!.userId;
         }
-        if (shouldSetUserFields && fields.updatedBy !== false && 'updatedBy' in timestamped) {
+        if (shouldSetUserFields && fields.updatedBy !== false) {
           (timestamped as any).updatedBy = options.userContext!.userId;
         }
         break;
@@ -259,7 +259,7 @@ export class MonguardCollection<T extends BaseDocument, TRefId = DefaultReferenc
         if (shouldSetTimestamps && fields.updatedAt !== false) {
           (timestamped as any).updatedAt = timestamp;
         }
-        if (shouldSetUserFields && fields.updatedBy !== false && 'updatedBy' in timestamped) {
+        if (shouldSetUserFields && fields.updatedBy !== false) {
           (timestamped as any).updatedBy = options.userContext!.userId;
         }
         delete (timestamped as any).deletedAt;
@@ -276,13 +276,13 @@ export class MonguardCollection<T extends BaseDocument, TRefId = DefaultReferenc
         if (fields.deletedAt === true && shouldSetTimestamps) {
           (timestamped as any).deletedAt = timestamp;
         }
-        if (fields.createdBy === true && shouldSetUserFields && 'createdBy' in timestamped) {
+        if (fields.createdBy === true && shouldSetUserFields) {
           (timestamped as any).createdBy = options.userContext!.userId;
         }
-        if (fields.updatedBy === true && shouldSetUserFields && 'updatedBy' in timestamped) {
+        if (fields.updatedBy === true && shouldSetUserFields) {
           (timestamped as any).updatedBy = options.userContext!.userId;
         }
-        if (fields.deletedBy === true && shouldSetUserFields && 'deletedBy' in timestamped) {
+        if (fields.deletedBy === true && shouldSetUserFields) {
           (timestamped as any).deletedBy = options.userContext!.userId;
         }
         break;
@@ -308,7 +308,7 @@ export class MonguardCollection<T extends BaseDocument, TRefId = DefaultReferenc
       document.createdAt = finalTimestamp;
     }
 
-    if (autoFieldConfig.enableAutoUserTracking !== false && userContext && 'createdBy' in document) {
+    if (autoFieldConfig.enableAutoUserTracking !== false && userContext) {
       document.createdBy = userContext.userId;
     }
   }
@@ -330,7 +330,7 @@ export class MonguardCollection<T extends BaseDocument, TRefId = DefaultReferenc
       document.updatedAt = finalTimestamp;
     }
 
-    if (autoFieldConfig.enableAutoUserTracking !== false && userContext && 'updatedBy' in document) {
+    if (autoFieldConfig.enableAutoUserTracking !== false && userContext) {
       document.updatedBy = userContext.userId;
     }
   }
@@ -354,12 +354,8 @@ export class MonguardCollection<T extends BaseDocument, TRefId = DefaultReferenc
     }
 
     if (autoFieldConfig.enableAutoUserTracking !== false && userContext) {
-      if ('deletedBy' in document) {
-        document.deletedBy = userContext.userId;
-      }
-      if ('updatedBy' in document) {
-        document.updatedBy = userContext.userId;
-      }
+      document.deletedBy = userContext.userId;
+      document.updatedBy = userContext.userId;
     }
   }
 
@@ -384,7 +380,7 @@ export class MonguardCollection<T extends BaseDocument, TRefId = DefaultReferenc
       document.updatedAt = finalTimestamp;
     }
 
-    if (autoFieldConfig.enableAutoUserTracking !== false && userContext && 'updatedBy' in document) {
+    if (autoFieldConfig.enableAutoUserTracking !== false && userContext) {
       document.updatedBy = userContext.userId;
     }
   }

--- a/packages/monguard/tests/unit/monguard-collection-internals.test.ts
+++ b/packages/monguard/tests/unit/monguard-collection-internals.test.ts
@@ -153,14 +153,14 @@ describe('MonguardCollection Internal Methods', () => {
       expect(result.createdAt).toBeUndefined();
     });
 
-    it('should not add user fields if document does not have them', () => {
+    it('should add user fields even if document does not have them initially', () => {
       const document = { name: 'John', email: 'john@example.com' };
       const userContext = TestDataFactory.createUserContext();
 
       const result = collection.testAddTimestamps(document, false, userContext);
 
-      expect(result.createdBy).toBeUndefined();
-      expect(result.updatedBy).toBeUndefined();
+      expect(result.createdBy).toBeDefined();
+      expect(result.updatedBy).toBeDefined();
     });
 
     it('should handle string userId in user context', () => {


### PR DESCRIPTION
Fixed an issue where the `createdBy` field was not being set during `collection.create()`. The root cause was overly strict conditions in `updateAutoFields` and related helper methods that required user-tracking fields to already exist in the document.

Changes:
- Removed unnecessary field existence checks for `createdBy`, `updatedBy`, `deletedBy`
- Updated logic in `updateAutoFields`, `setCreatedFields`, `setUpdatedFields`, and `setDeletedFields`
- Adjusted unit tests to reflect the corrected behavior

Now, user-tracking fields are correctly applied during both creation and update when a user context is present. All tests pass and code adheres to type and lint standards.